### PR TITLE
Introduce CI and fix wasm32 build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build_and_check:
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - wasm32-unknown-unknown
+
+    name: Build Check ${{ matrix.target }}
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install ${{ matrix.target }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+
+      - name: check build
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target ${{matrix.target}} --all-features
+
+  test:
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+
+    name: Test ${{ matrix.target }}
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install ${{ matrix.target }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+
+      - name: test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target ${{matrix.target}}
+
+      - name: test --all-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target ${{matrix.target}} --all-features
+
+      # This is currently broken because
+      # reqwest is not actually optional
+      #
+      # - name: test --no-default-features
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: test
+      #     args: --target ${{matrix.target}} --no-default-features
+

--- a/src/range_client.rs
+++ b/src/range_client.rs
@@ -3,7 +3,15 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use std::str;
 
+#[cfg(not(target_arch = "wasm32"))]
 #[async_trait]
+pub(crate) trait HttpRangeClient {
+    fn new() -> Self;
+    async fn get_range(&self, url: &str, range: &str) -> Result<Bytes>;
+}
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait(?Send)]
 pub(crate) trait HttpRangeClient {
     fn new() -> Self;
     async fn get_range(&self, url: &str, range: &str) -> Result<Bytes>;

--- a/src/reqwest_client.rs
+++ b/src/reqwest_client.rs
@@ -3,7 +3,32 @@ use crate::range_client::{GenericHttpRangeClient, HttpRangeClient};
 use async_trait::async_trait;
 use bytes::Bytes;
 
+#[cfg(not(target_arch = "wasm32"))]
 #[async_trait]
+impl HttpRangeClient for reqwest::Client {
+    fn new() -> Self {
+        reqwest::Client::new()
+    }
+    async fn get_range(&self, url: &str, range: &str) -> Result<Bytes> {
+        let response = self
+            .get(url)
+            .header("Range", range)
+            .send()
+            .await
+            .map_err(|e| HttpError::HttpError(e.to_string()))?;
+        if !response.status().is_success() {
+            return Err(HttpError::HttpStatus(response.status().as_u16()));
+        }
+        response
+            .bytes()
+            .await
+            .map_err(|e| HttpError::HttpError(e.to_string()))
+    }
+}
+
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait(?Send)]
 impl HttpRangeClient for reqwest::Client {
     fn new() -> Self {
         reqwest::Client::new()


### PR DESCRIPTION
Fixes #1 

flatgeobuf (as of at least version "0.7.4") used to build for wasm32. Some time between then and 0.9.5, we lost that ability.

Also this adds CI to show the error and the fix.
