### PR TITLE
Sync reader with Seek+Read implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --target ${{matrix.target}}
+          args: --target ${{matrix.target}} --no-default-features --features=reqwest-async
 
   test:
     strategy:
@@ -62,12 +62,8 @@ jobs:
           command: test
           args: --target ${{matrix.target}} --all-features -- --test-threads 1
 
-      # This is currently broken because
-      # reqwest is not actually optional
-      #
-      # - name: test --no-default-features
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: test
-      #     args: --target ${{matrix.target}} --no-default-features
-
+      - name: test --no-default-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target ${{matrix.target}} --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
           - wasm32-unknown-unknown
 
     name: Build Check ${{ matrix.target }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --target ${{matrix.target}} --all-features
+          args: --target ${{matrix.target}}
 
   test:
     strategy:
@@ -37,7 +37,7 @@ jobs:
           - x86_64-unknown-linux-gnu
 
     name: Test ${{ matrix.target }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --target ${{matrix.target}} --all-features
+          args: --target ${{matrix.target}} --all-features -- --test-threads 1
 
       # This is currently broken because
       # reqwest is not actually optional

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ reqwest-async = ["reqwest"]
 reqwest-sync = ["reqwest/blocking"]
 
 [dependencies]
-byteorder = "1.4.2"
-reqwest = { version = "0.11.0", default-features = false, features = ["default-tls"], optional = true }
-bytes = { version = "1.0.1" }
-thiserror = "1.0"
-log = "0.4.13"
 async-trait = "0.1.51"
+byteorder = "1.4.2"
+bytes = "1.0.1"
+log = "0.4.13"
+reqwest = { version = "0.11.0", default-features = false, features = ["default-tls"], optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
-tokio = { version = "1.0.2", default-features = false, features = ["rt-multi-thread", "macros"] }
 env_logger = "0.10.0"
+tokio = { version = "1.0.2", default-features = false, features = ["rt-multi-thread", "macros"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["http", "reader", "buffer"]
 
 [features]
 default = ["reqwest-sync", "reqwest-async"]
-logging = ["log"]
 reqwest-async = ["reqwest"]
 reqwest-sync = ["reqwest/blocking"]
 
@@ -21,7 +20,7 @@ byteorder = "1.4.2"
 reqwest = { version = "0.11.0", default-features = false, features = ["default-tls"], optional = true }
 bytes = { version = "1.0.1" }
 thiserror = "1.0"
-log = { version = "0.4.13", optional = true }
+log = "0.4.13"
 async-trait = "0.1.51"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ async-trait = "0.1.51"
 [dev-dependencies]
 tokio = { version = "1.0.2", default-features = false, features = ["rt-multi-thread", "macros"] }
 env_logger = "0.10.0"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ async-trait = "0.1.51"
 
 [dev-dependencies]
 tokio = { version = "1.0.2", default-features = false, features = ["rt-multi-thread", "macros"] }
+env_logger = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ byteorder = "1.4.2"
 reqwest = { version = "0.11.0", default-features = false, features = ["default-tls"], optional = true }
 bytes = { version = "1.0.1" }
 thiserror = "1.0"
-log = "0.4.13"
+log = { version = "0.4.13", optional = true }
 async-trait = "0.1.51"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["http", "reader", "buffer"]
 
 [features]
 default = ["reqwest"]
+sync = ["reqwest?/blocking"]
 
 [dependencies]
 byteorder = "1.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ license = "MIT/Apache-2.0"
 keywords = ["http", "reader", "buffer"]
 
 [features]
-default = ["reqwest"]
-sync = ["reqwest?/blocking"]
+default = ["reqwest-sync", "reqwest-async"]
+logging = ["log"]
+reqwest-async = ["reqwest"]
+reqwest-sync = ["reqwest/blocking"]
 
 [dependencies]
 byteorder = "1.4.2"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 HTTP client for HTTP Range requests with a buffer optimized for sequential requests.
 
+Implements Seek+Read for blocking clients, which makes it a drop-in replacement for local files.
 
-Usage example:
+Usage examples:
 
     use http_range_client::*;
 
@@ -12,3 +13,10 @@ Usage example:
     assert_eq!(bytes, b"fgb");
     let version = client.get_bytes(1).await?; // From buffer - no HTTP request!
     assert_eq!(version, [3]);
+
+    let mut client =
+        HttpReader::new("https://www.rust-lang.org/static/images/favicon-32x32.png");
+    client.seek(SeekFrom::Start(1)).ok();
+    let mut bytes = [0; 3];
+    client.read_exact(&mut bytes)?;
+    assert_eq!(&bytes, b"PNG");

--- a/README.md
+++ b/README.md
@@ -8,5 +8,7 @@ Usage example:
     use http_range_client::*;
 
     let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
-    let bytes = client.get_range(0, 3, 256).await?;
+    let bytes = client.min_req_size(256).get_range(0, 3).await?;
     assert_eq!(bytes, "fgb".as_bytes());
+    let version = client.get_bytes(1).await?; // From buffer - no HTTP request!
+    assert_eq!(version, &[3]);

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Usage example:
 
     let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
     let bytes = client.min_req_size(256).get_range(0, 3).await?;
-    assert_eq!(bytes, "fgb".as_bytes());
+    assert_eq!(bytes, b"fgb");
     let version = client.get_bytes(1).await?; // From buffer - no HTTP request!
-    assert_eq!(version, &[3]);
+    assert_eq!(version, [3]);

--- a/src/buffered_range_client.rs
+++ b/src/buffered_range_client.rs
@@ -8,6 +8,9 @@ use std::str;
 pub struct BufferedHttpRangeClient {
     http_client: HttpClient,
     buf: BytesMut,
+    min_req_size: usize,
+    /// Current position for Read+Seek implementation
+    offset: usize,
     /// Lower index of buffer relative to input stream
     head: usize,
 }
@@ -17,16 +20,28 @@ impl BufferedHttpRangeClient {
         BufferedHttpRangeClient {
             http_client: HttpClient::new(url),
             buf: BytesMut::new(),
+            min_req_size: 1024,
+            offset: 0,
             head: 0,
         }
     }
 
-    fn get_request_range(
-        &mut self,
-        begin: usize,
-        length: usize,
-        min_req_size: usize,
-    ) -> Option<(usize, usize)> {
+    /// Set minimal request size.
+    pub fn set_min_req_size(&mut self, size: usize) {
+        self.min_req_size = size;
+    }
+
+    /// Set minimal request size.
+    pub fn min_req_size(&mut self, size: usize) -> &mut Self {
+        self.set_min_req_size(size);
+        self
+    }
+
+    fn tail(&self) -> usize {
+        self.head + self.buf.len()
+    }
+
+    fn get_request_range(&mut self, begin: usize, length: usize) -> Option<(usize, usize)> {
         //
         //            head  begin    tail
         //       +------+-----+---+---+------------+
@@ -51,79 +66,150 @@ impl BufferedHttpRangeClient {
 
             // Read additional bytes into buffer
             let range_begin = max(begin, self.tail());
-            let range_length = max(begin + length - range_begin, min_req_size);
+            let range_length = max(begin + length - range_begin, self.min_req_size);
             Some((range_begin, range_length))
         } else {
             None
         }
     }
+}
 
-    fn tail(&self) -> usize {
-        self.head + self.buf.len()
+#[cfg(not(feature = "sync"))]
+mod nonblocking {
+    use super::*;
+
+    impl BufferedHttpRangeClient {
+        /// Get `length` bytes with offset `begin`.
+        pub async fn get_range(&mut self, begin: usize, length: usize) -> Result<&[u8]> {
+            if let Some((range_begin, range_length)) = self.get_request_range(begin, length) {
+                let bytes = self
+                    .http_client
+                    .get_range(range_begin, range_length)
+                    .await?;
+                self.buf.put(bytes);
+            }
+            self.offset = begin + length;
+            // Return slice from buffer
+            let lower = begin - self.head;
+            Ok(&self.buf[lower..lower + length])
+        }
+
+        /// Get `length` bytes from current offset.
+        pub async fn get_bytes(&mut self, length: usize) -> Result<&[u8]> {
+            self.get_range(self.offset, length).await
+        }
+    }
+}
+
+#[cfg(feature = "sync")]
+mod sync {
+    use super::*;
+    use bytes::Buf;
+    use std::io::{Read, Seek, SeekFrom};
+
+    impl BufferedHttpRangeClient {
+        /// Get `length` bytes with offset `begin`.
+        pub fn get_range(&mut self, begin: usize, length: usize) -> Result<&[u8]> {
+            if let Some((range_begin, range_length)) = self.get_request_range(begin, length) {
+                let bytes = self.http_client.get_range(range_begin, range_length)?;
+                self.buf.put(bytes);
+            }
+            self.offset = begin + length;
+            // Return slice from buffer
+            let lower = begin - self.head;
+            Ok(&self.buf[lower..lower + length])
+        }
+
+        /// Get `length` bytes from current offset.
+        pub fn get_bytes(&mut self, length: usize) -> Result<&[u8]> {
+            self.get_range(self.offset, length)
+        }
     }
 
-    /// Get `length` bytes with offset `begin`.
-    ///
-    /// When not already in buffer, request at least `min_req_size` bytes.
-    #[cfg(not(feature = "sync"))]
-    pub async fn get_range(
-        &mut self,
-        begin: usize,
-        length: usize,
-        min_req_size: usize,
-    ) -> Result<&[u8]> {
-        if let Some((range_begin, range_length)) =
-            self.get_request_range(begin, length, min_req_size)
-        {
-            let bytes = self
-                .http_client
-                .get_range(range_begin, range_length)
-                .await?;
-            self.buf.put(bytes);
+    impl Read for BufferedHttpRangeClient {
+        fn read(&mut self, buf: &mut [u8]) -> std::result::Result<usize, std::io::Error> {
+            let length = buf.len();
+            debug!("Offset: {}, Length: {length}", self.offset);
+            let mut bytes = self.get_range(self.offset as usize, length).unwrap();
+            bytes.copy_to_slice(buf);
+            Ok(length)
         }
-        // Return slice from buffer
-        let lower = begin - self.head;
-        Ok(&self.buf[lower..lower + length])
     }
 
-    /// Get `length` bytes with offset `begin`.
-    ///
-    /// When not already in buffer, request at least `min_req_size` bytes.
-    #[cfg(feature = "sync")]
-    pub fn get_range(&mut self, begin: usize, length: usize, min_req_size: usize) -> Result<&[u8]> {
-        if let Some((range_begin, range_length)) =
-            self.get_request_range(begin, length, min_req_size)
-        {
-            let bytes = self.http_client.get_range(range_begin, range_length)?;
-            self.buf.put(bytes);
+    impl Seek for BufferedHttpRangeClient {
+        fn seek(&mut self, pos: SeekFrom) -> std::result::Result<u64, std::io::Error> {
+            match pos {
+                SeekFrom::Start(p) => {
+                    self.offset = p as usize;
+                    Ok(p)
+                }
+                SeekFrom::End(_) => Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Request size unkonwn",
+                )),
+                SeekFrom::Current(p) => {
+                    self.offset = self.offset.saturating_add_signed(p as isize);
+                    Ok(self.offset as u64)
+                }
+            }
         }
-        // Return slice from buffer
-        let lower = begin - self.head;
-        Ok(&self.buf[lower..lower + length])
     }
 }
 
 #[cfg(test)]
-mod test {
+#[cfg(not(feature = "sync"))]
+mod test_async {
     use crate::{BufferedHttpRangeClient, Result};
 
-    #[cfg(not(feature = "sync"))]
     #[tokio::test]
     async fn http_read_async() -> Result<()> {
         let mut client =
             BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
-        let bytes = client.get_range(0, 3, 256).await?;
+        let bytes = client.min_req_size(256).get_range(0, 3).await?;
         assert_eq!(bytes, "fgb".as_bytes());
         Ok(())
     }
+}
 
-    #[cfg(feature = "sync")]
+#[cfg(test)]
+#[cfg(feature = "sync")]
+mod test_sync {
+    use crate::{BufferedHttpRangeClient, Result};
+    use std::io::Read;
+
     #[test]
     fn http_read_sync() -> Result<()> {
         let mut client =
             BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
-        let bytes = client.get_range(0, 3, 256)?;
+        let bytes = client.min_req_size(256).get_range(0, 3)?;
         assert_eq!(bytes, "fgb".as_bytes());
+
+        let version = client.get_bytes(1)?;
+        assert_eq!(version, &[3]);
+
+        let bytes = client.get_bytes(3)?;
+        assert_eq!(bytes, "fgb".as_bytes());
+        Ok(())
+    }
+
+    #[test]
+    fn io_read() -> std::io::Result<()> {
+        std::env::set_var("RUST_LOG", "debug");
+        env_logger::init();
+
+        let mut client =
+            BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
+        let mut bytes = [0; 3];
+        client.min_req_size(256).read_exact(&mut bytes)?;
+        assert_eq!(&bytes, b"fgb");
+
+        let mut version = [0; 1];
+        client.read_exact(&mut version)?;
+        assert_eq!(&version, &[3]);
+
+        let mut bytes = [0; 3];
+        client.read_exact(&mut bytes)?;
+        assert_eq!(&bytes, b"fgb");
         Ok(())
     }
 }

--- a/src/buffered_range_client.rs
+++ b/src/buffered_range_client.rs
@@ -175,7 +175,7 @@ mod test_async {
 #[cfg(feature = "sync")]
 mod test_sync {
     use crate::{BufferedHttpRangeClient, Result};
-    use std::io::Read;
+    use std::io::{Read, Seek, SeekFrom};
 
     #[test]
     fn http_read_sync() -> Result<()> {
@@ -199,12 +199,9 @@ mod test_sync {
 
         let mut client =
             BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
-        let mut bytes = [0; 3];
-        client.min_req_size(256).read_exact(&mut bytes)?;
-        assert_eq!(&bytes, b"fgb");
-
+        client.seek(SeekFrom::Start(3)).ok();
         let mut version = [0; 1];
-        client.read_exact(&mut version)?;
+        client.min_req_size(256).read_exact(&mut version)?;
         assert_eq!(&version, &[3]);
 
         let mut bytes = [0; 3];

--- a/src/buffered_range_client.rs
+++ b/src/buffered_range_client.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
 use bytes::{BufMut, BytesMut};
+use log::{debug, trace};
 use std::cmp::{max, min};
 use std::str;
 
@@ -39,8 +40,7 @@ impl HttpRangeBuffer {
         //                    +---+
         //                    length
 
-        #[cfg(feature = "logging")]
-        log::trace!("read begin: {begin}, Length: {length}");
+        trace!("read begin: {begin}, Length: {length}");
         // Download additional bytes if requested range is not in buffer
         if begin + length > self.tail() || begin < self.head {
             // Remove bytes before new begin
@@ -71,7 +71,6 @@ pub(crate) mod nonblocking {
         http_client: T,
         url: String,
         buffer: HttpRangeBuffer,
-        #[cfg(feature = "logging")]
         stats: stats::RequestStats,
     }
 
@@ -81,7 +80,6 @@ pub(crate) mod nonblocking {
                 http_client,
                 url: url.to_string(),
                 buffer: HttpRangeBuffer::new(),
-                #[cfg(feature = "logging")]
                 stats: stats::RequestStats::default(),
             }
         }
@@ -99,7 +97,6 @@ pub(crate) mod nonblocking {
 
         fn range(&mut self, begin: usize, length: usize) -> String {
             let range = format!("bytes={begin}-{}", begin + length - 1);
-            #[cfg(feature = "logging")]
             self.stats.log_get_range(begin, length, &range);
             range
         }
@@ -130,9 +127,8 @@ pub(crate) mod nonblocking {
     }
 }
 
-#[cfg(feature = "logging")]
 pub(crate) mod stats {
-    use log::debug;
+    use super::*;
 
     #[derive(Default)]
     pub(crate) struct RequestStats {
@@ -163,7 +159,6 @@ pub(crate) mod sync {
         http_client: T,
         url: String,
         buffer: HttpRangeBuffer,
-        #[cfg(feature = "logging")]
         stats: stats::RequestStats,
     }
 
@@ -173,7 +168,6 @@ pub(crate) mod sync {
                 http_client,
                 url: url.to_string(),
                 buffer: HttpRangeBuffer::new(),
-                #[cfg(feature = "logging")]
                 stats: stats::RequestStats::default(),
             }
         }
@@ -191,7 +185,6 @@ pub(crate) mod sync {
 
         fn range(&mut self, begin: usize, length: usize) -> String {
             let range = format!("bytes={begin}-{}", begin + length - 1);
-            #[cfg(feature = "logging")]
             self.stats.log_get_range(begin, length, &range);
             range
         }

--- a/src/buffered_range_client.rs
+++ b/src/buffered_range_client.rs
@@ -129,7 +129,8 @@ mod sync {
     impl Read for BufferedHttpRangeClient {
         fn read(&mut self, buf: &mut [u8]) -> std::result::Result<usize, std::io::Error> {
             let length = buf.len();
-            debug!("Offset: {}, Length: {length}", self.offset);
+            #[cfg(feature = "log")]
+            log::debug!("read offset: {}, Length: {length}", self.offset);
             let mut bytes = self.get_range(self.offset, length).unwrap();
             bytes.copy_to_slice(buf);
             Ok(length)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@
 //! # async fn get() -> Result<()> {
 //! let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
 //! let bytes = client.min_req_size(256).get_range(0, 3).await?;
-//! assert_eq!(bytes, "fgb".as_bytes());
+//! assert_eq!(bytes, b"fgb");
 //! let version = client.get_bytes(1).await?; // From buffer - no HTTP request!
-//! assert_eq!(version, &[3]);
+//! assert_eq!(version, [3]);
 //! # Ok(())
 //! # }
 //!
@@ -21,9 +21,9 @@
 //! # fn get() -> Result<()> {
 //! let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
 //! let bytes = client.min_req_size(256).get_range(0, 3)?;
-//! assert_eq!(bytes, "fgb".as_bytes());
+//! assert_eq!(bytes, b"fgb");
 //! let version = client.get_bytes(1)?; // From buffer - no HTTP request!
-//! assert_eq!(version, &[3]);
+//! assert_eq!(version, [3]);
 //! # Ok(())
 //! # }
 //!
@@ -35,7 +35,7 @@
 //! client.seek(SeekFrom::Start(3)).ok();
 //! let mut version = [0; 1];
 //! client.min_req_size(256).read_exact(&mut version)?;
-//! assert_eq!(&version, &[3]);
+//! assert_eq!(version, [3]);
 //! let mut bytes = [0; 3];
 //! client.read_exact(&mut bytes)?;
 //! assert_eq!(&bytes, b"fgb");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,20 @@
 //! ```
 //! use http_range_client::*;
 //!
+//! // Async API (without feature `sync`):
+//! # #[cfg(not(feature = "sync"))]
 //! # async fn get() -> Result<()> {
 //! let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
 //! let bytes = client.get_range(0, 3, 256).await?;
+//! assert_eq!(bytes, "fgb".as_bytes());
+//! # Ok(())
+//! # }
+//!
+//! // Blocking API (with feature `sync`):
+//! # #[cfg(feature = "sync")]
+//! # fn get() -> Result<()> {
+//! let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
+//! let bytes = client.get_range(0, 3, 256)?;
 //! assert_eq!(bytes, "fgb".as_bytes());
 //! # Ok(())
 //! # }
@@ -24,5 +35,7 @@ mod reqwest_client;
 
 pub use buffered_range_client::BufferedHttpRangeClient;
 pub use error::*;
-#[cfg(feature = "reqwest")]
-pub(crate) use reqwest_client::HttpClient;
+#[cfg(all(feature = "reqwest", not(feature = "sync")))]
+pub(crate) use reqwest_client::nonblocking::HttpClient;
+#[cfg(all(feature = "reqwest", feature = "sync"))]
+pub(crate) use reqwest_client::sync::HttpClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,10 @@
 //! # #[cfg(not(feature = "sync"))]
 //! # async fn get() -> Result<()> {
 //! let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
-//! let bytes = client.get_range(0, 3, 256).await?;
+//! let bytes = client.min_req_size(256).get_range(0, 3).await?;
 //! assert_eq!(bytes, "fgb".as_bytes());
+//! let version = client.get_bytes(1).await?; // From buffer - no HTTP request!
+//! assert_eq!(version, &[3]);
 //! # Ok(())
 //! # }
 //!
@@ -18,8 +20,24 @@
 //! # #[cfg(feature = "sync")]
 //! # fn get() -> Result<()> {
 //! let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
-//! let bytes = client.get_range(0, 3, 256)?;
+//! let bytes = client.min_req_size(256).get_range(0, 3)?;
 //! assert_eq!(bytes, "fgb".as_bytes());
+//! let version = client.get_bytes(1)?; // From buffer - no HTTP request!
+//! assert_eq!(version, &[3]);
+//! # Ok(())
+//! # }
+//!
+//! // Seek+Read API (with feature `sync`):
+//! # #[cfg(feature = "sync")]
+//! # fn read() -> std::io::Result<()> {
+//! use std::io::Read;
+//! let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
+//! let mut bytes = [0; 3];
+//! client.min_req_size(256).read_exact(&mut bytes)?;
+//! assert_eq!(&bytes, b"fgb");
+//! let mut version = [0; 1];
+//! client.read_exact(&mut version)?;
+//! assert_eq!(&version, &[3]);
 //! # Ok(())
 //! # }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,15 @@
 //! // Seek+Read API (with feature `sync`):
 //! # #[cfg(feature = "sync")]
 //! # fn read() -> std::io::Result<()> {
-//! use std::io::Read;
+//! use std::io::{Read, Seek, SeekFrom};
 //! let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
-//! let mut bytes = [0; 3];
-//! client.min_req_size(256).read_exact(&mut bytes)?;
-//! assert_eq!(&bytes, b"fgb");
+//! client.seek(SeekFrom::Start(3)).ok();
 //! let mut version = [0; 1];
-//! client.read_exact(&mut version)?;
+//! client.min_req_size(256).read_exact(&mut version)?;
 //! assert_eq!(&version, &[3]);
+//! let mut bytes = [0; 3];
+//! client.read_exact(&mut bytes)?;
+//! assert_eq!(&bytes, b"fgb");
 //! # Ok(())
 //! # }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,6 @@
 //! # }
 //! ```
 
-#[macro_use]
-extern crate log;
-
 mod buffered_range_client;
 mod error;
 mod range_client;

--- a/src/range_client.rs
+++ b/src/range_client.rs
@@ -1,84 +1,23 @@
 use crate::error::Result;
-#[cfg(not(feature = "sync"))]
 use async_trait::async_trait;
 use bytes::Bytes;
 use std::str;
 
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(not(feature = "sync"))]
 #[async_trait]
-pub(crate) trait HttpRangeClient {
-    fn new() -> Self;
+/// Async HTTP client for Range requests
+pub trait AsyncHttpRangeClient {
     async fn get_range(&self, url: &str, range: &str) -> Result<Bytes>;
 }
 
 #[cfg(target_arch = "wasm32")]
-#[cfg(not(feature = "sync"))]
 #[async_trait(?Send)]
-pub(crate) trait HttpRangeClient {
-    fn new() -> Self;
+/// Async HTTP client for Range requests
+pub trait AsyncHttpRangeClient {
     async fn get_range(&self, url: &str, range: &str) -> Result<Bytes>;
 }
 
-#[cfg(feature = "sync")]
-pub(crate) trait HttpRangeClient {
-    fn new() -> Self;
+/// Sync HTTP client for Range requests
+pub trait SyncHttpRangeClient {
     fn get_range(&self, url: &str, range: &str) -> Result<Bytes>;
-}
-
-/// HTTP client for HTTP Range requests (https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests)
-pub(crate) struct GenericHttpRangeClient<T: HttpRangeClient> {
-    client: T,
-    url: String,
-    #[cfg(feature = "log")]
-    stats: stats::RequestStats,
-}
-
-#[cfg(feature = "log")]
-pub(crate) mod stats {
-    use log::debug;
-
-    #[derive(Default)]
-    pub(crate) struct RequestStats {
-        requests_ever_made: usize,
-        bytes_ever_requested: usize,
-    }
-
-    impl RequestStats {
-        pub fn log_get_range(&mut self, _begin: usize, length: usize, range: &str) {
-            self.requests_ever_made += 1;
-            self.bytes_ever_requested += length;
-            debug!(
-                "request: #{}, bytes: (this_request: {length}, ever: {}), Range: {range}",
-                self.requests_ever_made, self.bytes_ever_requested,
-            );
-        }
-    }
-}
-
-impl<T: HttpRangeClient> GenericHttpRangeClient<T> {
-    pub fn new(url: &str) -> Self {
-        GenericHttpRangeClient {
-            client: T::new(),
-            url: url.to_string(),
-            #[cfg(feature = "log")]
-            stats: stats::RequestStats::default(),
-        }
-    }
-    fn get_range_header(&mut self, begin: usize, length: usize) -> String {
-        let range = format!("bytes={begin}-{}", begin + length - 1);
-        #[cfg(feature = "log")]
-        self.stats.log_get_range(begin, length, &range);
-        range
-    }
-    #[cfg(not(feature = "sync"))]
-    pub async fn get_range(&mut self, begin: usize, length: usize) -> Result<Bytes> {
-        let range = self.get_range_header(begin, length);
-        self.client.get_range(&self.url, &range).await
-    }
-    #[cfg(feature = "sync")]
-    pub fn get_range(&mut self, begin: usize, length: usize) -> Result<Bytes> {
-        let range = self.get_range_header(begin, length);
-        self.client.get_range(&self.url, &range)
-    }
 }

--- a/src/range_client.rs
+++ b/src/range_client.rs
@@ -66,7 +66,7 @@ impl<T: HttpRangeClient> GenericHttpRangeClient<T> {
         }
     }
     fn get_range_header(&mut self, begin: usize, length: usize) -> String {
-        let range = format!("bytes={}-{}", begin, begin + length - 1);
+        let range = format!("bytes={begin}-{}", begin + length - 1);
         #[cfg(feature = "log")]
         self.stats.log_get_range(begin, length, &range);
         range

--- a/src/reqwest_client.rs
+++ b/src/reqwest_client.rs
@@ -1,53 +1,83 @@
 use crate::error::{HttpError, Result};
 use crate::range_client::{GenericHttpRangeClient, HttpRangeClient};
-use async_trait::async_trait;
 use bytes::Bytes;
 
-#[cfg(not(target_arch = "wasm32"))]
-#[async_trait]
-impl HttpRangeClient for reqwest::Client {
-    fn new() -> Self {
-        reqwest::Client::new()
-    }
-    async fn get_range(&self, url: &str, range: &str) -> Result<Bytes> {
-        let response = self
-            .get(url)
-            .header("Range", range)
-            .send()
-            .await
-            .map_err(|e| HttpError::HttpError(e.to_string()))?;
-        if !response.status().is_success() {
-            return Err(HttpError::HttpStatus(response.status().as_u16()));
+#[cfg(not(feature = "sync"))]
+pub(crate) mod nonblocking {
+    use super::*;
+    use async_trait::async_trait;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[async_trait]
+    impl HttpRangeClient for reqwest::Client {
+        fn new() -> Self {
+            Self::new()
         }
-        response
-            .bytes()
-            .await
-            .map_err(|e| HttpError::HttpError(e.to_string()))
+        async fn get_range(&self, url: &str, range: &str) -> Result<Bytes> {
+            let response = self
+                .get(url)
+                .header("Range", range)
+                .send()
+                .await
+                .map_err(|e| HttpError::HttpError(e.to_string()))?;
+            if !response.status().is_success() {
+                return Err(HttpError::HttpStatus(response.status().as_u16()));
+            }
+            response
+                .bytes()
+                .await
+                .map_err(|e| HttpError::HttpError(e.to_string()))
+        }
     }
+
+    #[cfg(target_arch = "wasm32")]
+    #[async_trait(?Send)]
+    impl HttpRangeClient for reqwest::Client {
+        fn new() -> Self {
+            Self::new()
+        }
+        async fn get_range(&self, url: &str, range: &str) -> Result<Bytes> {
+            let response = self
+                .get(url)
+                .header("Range", range)
+                .send()
+                .await
+                .map_err(|e| HttpError::HttpError(e.to_string()))?;
+            if !response.status().is_success() {
+                return Err(HttpError::HttpStatus(response.status().as_u16()));
+            }
+            response
+                .bytes()
+                .await
+                .map_err(|e| HttpError::HttpError(e.to_string()))
+        }
+    }
+
+    pub(crate) type HttpClient = GenericHttpRangeClient<reqwest::Client>;
 }
 
+#[cfg(feature = "sync")]
+pub(crate) mod sync {
+    use super::*;
 
-#[cfg(target_arch = "wasm32")]
-#[async_trait(?Send)]
-impl HttpRangeClient for reqwest::Client {
-    fn new() -> Self {
-        reqwest::Client::new()
-    }
-    async fn get_range(&self, url: &str, range: &str) -> Result<Bytes> {
-        let response = self
-            .get(url)
-            .header("Range", range)
-            .send()
-            .await
-            .map_err(|e| HttpError::HttpError(e.to_string()))?;
-        if !response.status().is_success() {
-            return Err(HttpError::HttpStatus(response.status().as_u16()));
+    impl HttpRangeClient for reqwest::blocking::Client {
+        fn new() -> Self {
+            Self::new()
         }
-        response
-            .bytes()
-            .await
-            .map_err(|e| HttpError::HttpError(e.to_string()))
+        fn get_range(&self, url: &str, range: &str) -> Result<Bytes> {
+            let response = self
+                .get(url)
+                .header("Range", range)
+                .send()
+                .map_err(|e| HttpError::HttpError(e.to_string()))?;
+            if !response.status().is_success() {
+                return Err(HttpError::HttpStatus(response.status().as_u16()));
+            }
+            response
+                .bytes()
+                .map_err(|e| HttpError::HttpError(e.to_string()))
+        }
     }
-}
 
-pub(crate) type HttpClient = GenericHttpRangeClient<reqwest::Client>;
+    pub(crate) type HttpClient = GenericHttpRangeClient<reqwest::blocking::Client>;
+}


### PR DESCRIPTION
A first attempt implementing a sync API with Seek+Read support.

To have a similar API I've also changed the `get_range` API. What do you think @michaelkirk?

Module doc examples:
```rust
// Async API (without feature `sync`):
let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
let bytes = client.min_req_size(256).get_range(0, 3).await?;
assert_eq!(bytes, "fgb".as_bytes());
let version = client.get_bytes(1).await?; // From buffer - no HTTP request!
assert_eq!(version, &[3]);

// Blocking API (with feature `sync`):
let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
let bytes = client.min_req_size(256).get_range(0, 3)?;
assert_eq!(bytes, "fgb".as_bytes());
let version = client.get_bytes(1)?; // From buffer - no HTTP request!
assert_eq!(version, &[3]);

// Seek+Read API (with feature `sync`):
use std::io::{Read, Seek, SeekFrom};
let mut client = BufferedHttpRangeClient::new("https://flatgeobuf.org/test/data/countries.fgb");
client.seek(SeekFrom::Start(3)).ok();
let mut version = [0; 1];
client.min_req_size(256).read_exact(&mut version)?;
assert_eq!(&version, &[3]);
let mut bytes = [0; 3];
client.read_exact(&mut bytes)?;
assert_eq!(&bytes, b"fgb");
```