### PR TITLE
fix wasm ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,21 +6,21 @@ jobs:
   build_and_check:
     strategy:
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - wasm32-unknown-unknown
+        config:
+          - { target: x86_64-unknown-linux-gnu, features: "reqwest-async,ureq-sync" }
+          - { target: wasm32-unknown-unknown, features: "reqwest-async" }
 
-    name: Build Check ${{ matrix.target }}
+    name: Build Check ${{ matrix.config.target }}
     runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install ${{ matrix.target }}
+      - name: Install ${{ matrix.config.target }}
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: ${{ matrix.target }}
+          target: ${{ matrix.config.target }}
           profile: minimal
           override: true
 
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --target ${{matrix.target}} --no-default-features --features=reqwest-async,ureq-sync
+          args: --target ${{matrix.config.target}} --no-default-features --features=${{matrix.config.features}}
 
   test:
     strategy:


### PR DESCRIPTION
ureq used to build on wasm, but apparently it never actually worked:
https://github.com/algesten/ureq/issues/667

Now it no longer builds, so I've removed it from CI.
```
error: the wasm*-unknown-unknown targets are not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
Error:    --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.15/src/lib.rs:342:9
    |
342 | /         compile_error!("the wasm*-unknown-unknown targets are not supported by \
343 | |                         default, you may need to enable the \"js\" feature. \
344 | |                         For more information see: \
345 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared crate or module `imp`
Error:    --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.15/src/lib.rs:398:9
    |
398 |         imp::getrandom_inner(dest)?;
    |         ^^^ use of undeclared crate or module `imp`
```