### PR TITLE
Add rustls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ reqwest-async = ["reqwest"]
 reqwest-sync = ["reqwest/blocking"]
 ureq-sync = ["ureq"]
 default-tls = ["reqwest?/default-tls"]
+rustls-tls = ["reqwest?/rustls-tls"]
 
 [dependencies]
 async-trait = "0.1.51"


### PR DESCRIPTION
I get runtime issues about missing openssl version when `default-tls` feature is enabled, so it would be nice to have `rustls` as another option. 